### PR TITLE
Flesh out table rendering

### DIFF
--- a/src/app/Dice.elm
+++ b/src/app/Dice.elm
@@ -1,0 +1,19 @@
+module Dice exposing (emptyCup, Cup, cupFromIntList)
+
+
+type alias Die =
+    Int
+
+
+type alias Cup =
+    List Die
+
+
+emptyCup : Cup
+emptyCup =
+    []
+
+
+cupFromIntList : List Int -> Cup
+cupFromIntList =
+    identity

--- a/src/app/Table.elm
+++ b/src/app/Table.elm
@@ -14,10 +14,6 @@ import TableMsg exposing (Msg(..))
 import Dice
 
 
-type alias AppMsg =
-    Types.Msg
-
-
 type alias PlayerName =
     String
 
@@ -71,7 +67,7 @@ testPlayers =
     [ TablePlayer 1 "Joe" 6, TablePlayer 2 "Garrett" 5 ]
 
 
-view : (Msg -> AppMsg) -> Model -> Html AppMsg
+view : (Msg -> msg) -> Model -> Html msg
 view privateMsg { tablePlayers } =
     div []
         [ button [ onClick <| privateMsg CallLiar ] [ text "Liar!" ]
@@ -79,7 +75,7 @@ view privateMsg { tablePlayers } =
         ]
 
 
-playersView : TablePlayers -> Html AppMsg
+playersView : TablePlayers -> Html msg
 playersView tablePlayers =
     div [] <|
         List.map
@@ -87,7 +83,7 @@ playersView tablePlayers =
             tablePlayers
 
 
-playerView : TablePlayer -> Html AppMsg
+playerView : TablePlayer -> Html msg
 playerView { id, name, diceCount } =
     div []
         [ text name

--- a/src/app/Table.elm
+++ b/src/app/Table.elm
@@ -1,29 +1,95 @@
-module Table exposing (view, init, Msg)
+module Table exposing (view, init, initWithPlayersAndCup)
 
-import Html exposing (..)
+{-|
 
-
-{-
-
-   This module handles the view rendering for the table of players
+   This module handles the table of players,
    and everything relating to that.
 
 -}
 
+import Html exposing (..)
+import Html.Events exposing (..)
+import Types exposing (PlayerID)
+import TableMsg exposing (Msg(..))
+import Dice
 
-type Model
-    = Model
+
+type alias AppMsg =
+    Types.Msg
 
 
-type Msg
-    = Msg
+type alias PlayerName =
+    String
+
+
+type alias DiceCount =
+    Int
+
+
+type alias TablePlayer =
+    { id : PlayerID
+    , name : PlayerName
+    , diceCount : DiceCount
+    }
+
+
+type alias TablePlayers =
+    List TablePlayer
+
+
+type alias Model =
+    { tablePlayers : TablePlayers
+    , myCup : Dice.Cup
+    }
 
 
 init : Model
 init =
-    Model
+    { tablePlayers = noPlayers
+    , myCup = Dice.emptyCup
+    }
 
 
-view : Model -> Html Msg
-view model =
-    div [] []
+initWithPlayersAndCup : List ( Int, String, Int ) -> List Int -> Model
+initWithPlayersAndCup tuples cup =
+    let
+        tupleToPlayer ( id, name, diceCount ) =
+            { id = id, name = name, diceCount = diceCount }
+    in
+        { tablePlayers = List.map tupleToPlayer tuples
+        , myCup = Dice.cupFromIntList cup
+        }
+
+
+noPlayers : TablePlayers
+noPlayers =
+    []
+
+
+testPlayers : TablePlayers
+testPlayers =
+    [ TablePlayer 1 "Joe" 6, TablePlayer 2 "Garrett" 5 ]
+
+
+view : (Msg -> AppMsg) -> Model -> Html AppMsg
+view privateMsg { tablePlayers } =
+    div []
+        [ button [ onClick <| privateMsg CallLiar ] [ text "Liar!" ]
+        , playersView tablePlayers
+        ]
+
+
+playersView : TablePlayers -> Html AppMsg
+playersView tablePlayers =
+    div [] <|
+        List.map
+            playerView
+            tablePlayers
+
+
+playerView : TablePlayer -> Html AppMsg
+playerView { id, name, diceCount } =
+    div []
+        [ text name
+        , text (toString diceCount)
+        ]

--- a/src/app/TableMsg.elm
+++ b/src/app/TableMsg.elm
@@ -1,0 +1,13 @@
+module TableMsg exposing (Msg(..))
+
+{-|
+
+   This module has the Table Msg type
+   So that it can be accessed from several places
+
+-}
+
+
+type Msg
+    = CallLiar
+    | MakeBid

--- a/src/app/Types.elm
+++ b/src/app/Types.elm
@@ -1,15 +1,16 @@
 module Types exposing (..)
 
-import Table
+import TableMsg
+import Dice
 
 
-type alias CupOfDice =
-    List Int
+type alias PlayerID =
+    Int
 
 
 type alias Game =
     { gameState : Maybe GameState
-    , cup : Maybe CupOfDice
+    , cup : Maybe Dice.Cup
     , id : Int
     }
 
@@ -50,7 +51,7 @@ type Msg
     = CallLiar Int
     | MakeBid Bid
     | GetCup
-    | SetCup CupOfDice
+    | SetCup Dice.Cup
     | NextServerState ServerState
     | RoundFinished RoundResult
-    | TableMsg Table.Msg
+    | TableAction TableMsg.Msg

--- a/src/app/View.elm
+++ b/src/app/View.elm
@@ -1,6 +1,7 @@
 module View exposing (..)
 
 import Types exposing (..)
+import Dice exposing (Cup)
 import Html exposing (..)
 import Table
 
@@ -19,7 +20,7 @@ root model =
           --            [ text ("FaceValue: " ++ toString model.currentBid.faceValue) ]
           --        , p []
           --            [ text ("Player: " ++ firstPlayer model.players) ]
-        , tableView
+        , tableView [] []
         ]
 
 
@@ -33,6 +34,17 @@ firstPlayer players =
             "No Players Found"
 
 
-tableView : Html Msg
-tableView =
-    Html.map TableMsg (Table.view Table.init)
+tableView : List Player -> Dice.Cup -> Html Msg
+tableView players cup =
+    let
+        -- we have to fake ids until we have them
+        idAndPlayerTo3Tuple id { playerName, diceCount } =
+            ( id, playerName, diceCount )
+
+        ids =
+            List.range 1 <| List.length players
+
+        playersTuples =
+            List.map2 idAndPlayerTo3Tuple ids players
+    in
+        Table.view Types.TableAction <| Table.initWithPlayersAndCup playersTuples cup

--- a/src/elm-package.json
+++ b/src/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "Perudo Game front-end client",
+    "repository": "https://github.com/blake-education/perudo-client.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
This PR fleshes out the table rendering a bit more.

It also implements a bit of an experiment with `TEA`:

> Instead of making `Main` handle the lifting of `Table.view`, changed `Table.view` to be `: view : (Msg -> AppMsg) -> Model -> Html AppMsg` (`AppMsg` is an alias to `Types.Msg`). Then, if `Table.view` needs to use a message from `AppMsg`, it just does. If we *really* want to make it cleaner, we can use some helper functions to create these `AppMsg` messages so that they're totally decoupled.
